### PR TITLE
Support for trigger scripts to be passed the rms value as an argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,8 @@ The "soundmeter" command accepts the following options:
   -c, --collect  collect RMS values to determine thresholds
   -s SECS, --seconds SECS  time in seconds to run the meter (default forever)
   -a ACTION_TYPE, --action ACTION_TYPE  triggered action (``stop``, ``exec-stop`` and ``exec``)
-  -t THRESHOLD, --trigger THRESHOLD  trigger condition (threshold RMS and an optional number of consecutive triggering times, which defaults 1)   
-  -e FILE, --execute FILE  shell script to execute upon trigger (defaults to ``~/.soundmeter/trigger.sh``)
+  -t THRESHOLD, --trigger THRESHOLD  trigger condition (threshold RMS and an optional number of consecutive triggering times, which defaults 1)
+  -e FILE, --execute FILE  shell script to execute upon trigger (defaults to ``~/.soundmeter/trigger.sh``), can be configured to pass rms value as argument by setting ``rms_as_trigger_arg`` to ``True`` in ~/.soundmeter/config
   -d, --daemonize  run the meter in the background
   --log LOGFILE  log the meter (defaults to ``~/.soundmeter/log``)
   -v, --verbose         verbose mode
@@ -113,3 +113,4 @@ Some "dependency-required" parameters can be configured at ~/.soundmeter/config.
     channels = 2
     rate = 44100
     audio_segment_length = 0.5
+    rms_as_trigger_argument = False

--- a/sample_config
+++ b/sample_config
@@ -5,3 +5,4 @@ format = 8
 channels = 2
 rate = 44100
 audio_segment_length = 0.5
+rms_as_trigger_arg = False

--- a/soundmeter/settings.py
+++ b/soundmeter/settings.py
@@ -21,6 +21,8 @@ if config.has_section(PROG):
                 items[name] = int(items[name])
             elif name in ['audio_segment_length']:
                 items[name] = float(items[name])
+            elif name in ['rms_as_trigger_arg']:
+                items[name] = bool(items[name])
             else:
                 raise Exception('Unknown name "%s" in config' % name)
         except ValueError:
@@ -31,3 +33,4 @@ FORMAT = items.get('format') or pyaudio.paInt16
 CHANNELS = items.get('channels') or 2
 RATE = items.get('rate') or 44100
 AUDIO_SEGMENT_LENGTH = items.get('audio_segment_length') or 0.5
+RMS_AS_TRIGGER_ARG = items.get('rms_as_trigger_arg') or False


### PR DESCRIPTION
- Added basic support for rms to be passed as argument with trigger script. Example `trigger.sh 1234`
- Added config variable for rms as argument, allowing users to turn it on or off. Default is off to support current uses.
- Added README and config info