### PR TITLE
correct rms_as_trigger_arg key name in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,4 +113,4 @@ Some "dependency-required" parameters can be configured at ~/.soundmeter/config.
     channels = 2
     rate = 44100
     audio_segment_length = 0.5
-    rms_as_trigger_argument = False
+    rms_as_trigger_arg = False


### PR DESCRIPTION
was rms_as_trigger_argument, should be rms_as_trigger_arg